### PR TITLE
fix rules_ocaml demos

### DIFF
--- a/rules_ocaml/ppxlib/rewriters/get_env/BUILD.bazel
+++ b/rules_ocaml/ppxlib/rewriters/get_env/BUILD.bazel
@@ -14,7 +14,6 @@ load(
     "@rules_ocaml//build:rules.bzl",
     "ocaml_module",
     "ocaml_test",
-    "ocaml_module",
     "ppx_executable")
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
@@ -42,7 +41,6 @@ config_setting(
 ocaml_test(
     name = "test",
     main = "_Test",
-    test = "short"
 )
 
 ocaml_module(


### PR DESCRIPTION
The `ocaml_module` was imported twice and caused errors.

I am not sure about `test` param in `ocaml_test`, was it removed or renamed?